### PR TITLE
setup ci to have action test itself

### DIFF
--- a/.github/workflows/nowsecure.yml
+++ b/.github/workflows/nowsecure.yml
@@ -1,0 +1,44 @@
+# Copyright © 2022 NowSecure Inc.
+#
+# SPDX-License-Identifier: MIT
+
+name: NowSecure
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
+
+      - name: Get BitBar APK
+        run: |
+          curl -L \
+          https://github.com/bitbar/test-samples/raw/master/apps/android/bitbar-sample-app.apk \
+          -o app.apk
+
+      - name: NowSecure
+        uses: ./
+        timeout-minutes: 90
+        with:
+          token: ${{ secrets.NS_TOKEN }}
+          app_file: app.apk
+          group_id: ${{ secrets.NS_GROUP_ID }}
+
+      - name: Upload SARIF to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: NowSecure.sarif
+          path: ./NowSecure.sarif


### PR DESCRIPTION
The following change will make the gitlab action test itself, by checking out the repo and running the action at its current state of that particular commit.

changes:
  - test job to run the action
  - expose group_id and token as variables
  - setup integration to not run on forked PRs. Forks cannot use secrets. There are some workarounds, but the benefit of setting it up probably doesn't out weigh the possible secret exposure IMO. Instead the attempting contributor should provide a successful action job via a link to their fork. This could be outlined in the pull request template. 
 
Also a `CONTRIBUTING.md` could go a long way if you're interested. Since collaborators do not have access to the nowsecure/nowsecure-action repo secrets. The workflow for contributing requires that contributors fork the branch and setup their actions environment with their group id and token

I believe token and group_id would need to be added to this repo as well. Let me know what you think.

link to passing integration test https://github.com/dylanhitt/nowsecure-action/runs/5150503204?check_suite_focus=true

Regards