### PR TITLE
remove nowsecure scan on PR

### DIFF
--- a/.github/workflows/nowsecure.yml
+++ b/.github/workflows/nowsecure.yml
@@ -8,14 +8,10 @@ on:
   push:
     branches:
       - "*"
-  pull_request:
-    branches:
-      - main
 
 jobs:
   scan:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Running the nowsecure scan on both PR and push causes transient errors with the CI.

See [this PR for reference](https://github.com/nowsecure/nowsecure-action/pull/6).

Either the PR or Push event will cause a 

```
Error: NowSecure assessment submission failed: {"name":"Error","message":"Failed to send request to /system/queue/default 409","status":409}
    at /home/runner/work/nowsecure-action/nowsecure-action/webpack:/nowsecure-action/src/nowsecure-action.ts:65:1
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/work/nowsecure-action/nowsecure-action/webpack:/nowsecure-action/src/nowsecure-action.ts:29:1)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
Error: NowSecure assessment submission failed: {"name":"Error","message":"Failed to send request to /system/queue/default 409","status":409}
```

in the action itself.